### PR TITLE
Add param_overview which takes a 'pv' and returns a named list with t…

### DIFF
--- a/R/param_overview.R
+++ b/R/param_overview.R
@@ -19,7 +19,7 @@ param_overview <- function (pv) {
 print.param_overview <- function (x) {
   stopifnot("param_overview" %in% class(x))
   for (p_name in names(x)) {
-    cat(p_name, ": ", x[[p_name]], "\n")
+    cat(p_name, ": ", paste(x[[p_name]], collapse = ' '), "\n", sep = '')
   }
 }
 

--- a/R/param_overview.R
+++ b/R/param_overview.R
@@ -6,11 +6,7 @@
 #' @export
 param_overview <- function(pv){
   stopifnot( !is.null(pv$param) )
-  unique_params <- lapply(X = 1:ncol(pv$param),
-                          FUN = function(pcol){
-                            unique(pv$param[,pcol] %>% dplyr::pull()) 
-                          })
-  names(unique_params) <- names(pv$param)
+  unique_params <- lapply(pv$param, unique)
   class(unique_params) <- append(class(unique_params), "param_overview")
   return(unique_params)
 }

--- a/R/param_overview.R
+++ b/R/param_overview.R
@@ -3,29 +3,32 @@
 #' @param pv paramval object
 #' @return named list with names corresponding to \code{names(pv$param)}
 #' containing the unique values for each column of \code{pv$param}
+#'
 #' @export
-param_overview <- function(pv){
-  stopifnot( !is.null(pv$param) )
+param_overview <- function (pv) {
+  stopifnot(!is.null(pv$param))
   unique_params <- lapply(pv$param, unique)
   class(unique_params) <- append(class(unique_params), "param_overview")
-  return(unique_params)
+  return (unique_params)
 }
 
 #' print `param_overview` object
+#'
 #' @param x object of class `param_overview`
 #' @export
-print.param_overview <- function(x){
-  stopifnot( "param_overview" %in% class(x) )
-  for( p_name in names(x) ){
+print.param_overview <- function (x) {
+  stopifnot("param_overview" %in% class(x))
+  for (p_name in names(x)) {
     cat(p_name, ": ", x[[p_name]], "\n")
   }
 }
 
 #' summarize `param_overview` object
+#'
 #' @param x object of class `param_overview`
 #' @export
-summary.param_overview <- function(x){
-  stopifnot( "param_overview" %in% class(x) )
+summary.param_overview <- function (x) {
+  stopifnot("param_overview" %in% class(x))
   print(x)
 }
 

--- a/R/param_overview.R
+++ b/R/param_overview.R
@@ -1,8 +1,8 @@
 #' get an overview over all available param values in a paramval object
 #'
 #' @param pv paramval object
-#' @return named list with names corresponding to \code{names(pv$param)}
-#' containing the unique values for each column of \code{pv$param}
+#' @return named list with names corresponding to `names(pv$param)`
+#' containing the unique values for each column of `pv$param`
 #'
 #' @export
 param_overview <- function (pv) {

--- a/R/param_overview.R
+++ b/R/param_overview.R
@@ -1,0 +1,35 @@
+#' get an overview over all available param values in a paramval object
+#'
+#' @param pv paramval object
+#' @return named list with names corresponding to \code{names(pv$param)}
+#' containing the unique values for each column of \code{pv$param}
+#' @export
+param_overview <- function(pv){
+  stopifnot( !is.null(pv$param) )
+  unique_params <- lapply(X = 1:ncol(pv$param),
+                          FUN = function(pcol){
+                            unique(pv$param[,pcol] %>% dplyr::pull()) 
+                          })
+  names(unique_params) <- names(pv$param)
+  class(unique_params) <- append(class(unique_params), "param_overview")
+  return(unique_params)
+}
+
+#' print `param_overview` object
+#' @param x object of class `param_overview`
+#' @export
+print.param_overview <- function(x){
+  stopifnot( "param_overview" %in% class(x) )
+  for( p_name in names(x) ){
+    cat(p_name, ": ", x[[p_name]], "\n")
+  }
+}
+
+#' summarize `param_overview` object
+#' @param x object of class `param_overview`
+#' @export
+summary.param_overview <- function(x){
+  stopifnot( "param_overview" %in% class(x) )
+  print(x)
+}
+


### PR DESCRIPTION
…he unique values of all params. Provide print and summary functions.

example usage:

```r
> pv_load("ff", uwcf_3pt_full_mom_shell)
Loading uwcf_3pt_full_mom_shell ... took 0.36 seconds.
> param_overview(uwcf_3pt_full_mom_shell)
lattice_spacing_letter :  A B 
ensemble_base :  cA211.30 cA211.40 cA211.53 cB211.072 cB211.25 
ensemble :  cA211.30.32 cA211.40.24 cA211.53.24 cB211.072.64 cB211.25.24 cB211.25.32 cB211.25.48 
cor_id :  pi_3pt_scalar_ff 
fwd_flav :  u 
bwd_flav :  u 
seq_flav :  d 
snk_gamma :  5 
cur_gamma :  5 
src_gamma :  5 
src_psq_max :  3 2 
snk_psq_max :  3 2 
cur_displ_depth :  0 
mom_conservation :  FALSE 
match_displ_cur_gamma :  NA 
scalar_ff_type :  su2 su3octet su3singlet 
```

This makes exploratory analysis on PVs easier. 

@martin-ueding: As you can see, this currently only leaves the default white-space printed by `cat`. Should I increase?

@urbach Is this more or less what you had in mind? Thanks for the idea, I think this is a very useful tool to have.
